### PR TITLE
added option to auto adjust pointer only for x or y axis instead of both of them

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -376,6 +376,8 @@ type Pointer = {
   pointerLabelComponent?: Function;
   stripOverPointer?: boolean;
   autoAdjustPointerLabelPosition?: boolean;
+  autoAdjustPointerXLabelPosition?: boolean;
+  autoAdjustPointerYLabelPosition?: boolean;
   shiftPointerLabelX?: number;
   shiftPointerLabelY?: number;
   pointerLabelWidth?: number;
@@ -1941,6 +1943,14 @@ export const LineChart = (props: propTypes) => {
     pointerConfig && pointerConfig.autoAdjustPointerLabelPosition === false
       ? false
       : defaultPointerConfig.autoAdjustPointerLabelPosition;
+  const autoAdjustPointerXLabelPosition =
+    (pointerConfig && pointerConfig.autoAdjustPointerXLabelPosition === false) || (pointerConfig && pointerConfig.autoAdjustPointerLabelPosition === false)
+      ? false
+      : true
+  const autoAdjustPointerYLabelPosition =
+    (pointerConfig && pointerConfig.autoAdjustPointerYLabelPosition === false) || (pointerConfig && pointerConfig.autoAdjustPointerLabelPosition === false)
+      ? false
+      : true
   const pointerVanishDelay =
     pointerConfig && pointerConfig.pointerVanishDelay
       ? pointerConfig.pointerVanishDelay
@@ -2984,7 +2994,7 @@ export const LineChart = (props: propTypes) => {
 
     let left = 0,
       top = 0;
-    if (autoAdjustPointerLabelPosition) {
+    if (autoAdjustPointerXLabelPosition) {
       if (pointerX < pointerLabelWidth / 2) {
         left = 7;
       } else if (
@@ -3017,7 +3027,7 @@ export const LineChart = (props: propTypes) => {
       left = (pointerRadius || pointerWidth / 2) - 10 + shiftPointerLabelX;
     }
 
-    if (autoAdjustPointerLabelPosition) {
+    if (autoAdjustPointerYLabelPosition) {
       if (pointerLabelHeight - pointerYLocal > 10) {
         top = 10;
       } else {


### PR DESCRIPTION
If i activate autoAdjustPointerLabelPosition, the app renderer the pointerComponent bellow the line and the user finger covers the showed values.

So, i create two optional props: autoAdjustPointerXLabelPosition and autoAdjustPointerYLabelPosition, this value is default to true if autoAdjustPointerLabelPosition its true, but i can set one of them into false, allowing the developer to select according his use cases.