### PR TITLE
Fix missing unique key prop

### DIFF
--- a/src/PieChart/main.tsx
+++ b/src/PieChart/main.tsx
@@ -408,6 +408,7 @@ export const PieChartMain = (props: propTypes) => {
                   />
                 )}
                 <SvgText
+                  key={index + 'c'}
                   fill={item.textColor || textColor || colors[(index + 2) % 9]}
                   fontSize={item.textSize || textSize}
                   fontFamily={item.font || props.font}


### PR DESCRIPTION
Hello

While using this lib in my react-native project, I noticed a recurring error on using `showText` prop on the `PieChart` component.
I looked up the source code and spotted a missing unique key prop while mapping and rendering each pie elements.
The `SvgText` component is missing a key prop as being extracted from the mapped data, so I'm contributing to fix this issue.

Thank you for the project and taking time to review my pull request.

![image](https://user-images.githubusercontent.com/77301332/236649759-575b7555-0df5-4788-8c54-6734e9a7dcf6.png)
