### PR TITLE
Fix labels in bar/line-chart y-axis with negative values

### DIFF
--- a/src/Components/BarAndLineChartsWrapper/renderHorizSections.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderHorizSections.tsx
@@ -140,9 +140,15 @@ export const renderHorizSections = (props: horizSectionPropTypes) => {
         value.toFixed(roundToDigits ?? AxesAndRulesDefaults.roundToDigits),
       );
     }
+
+    let startIndex = noOfSections;
+    if (horizSectionsBelow.length > 0) {
+      startIndex += horizSectionsBelow.length;
+    }
+
     horizSections.push({
       value: yAxisLabelTexts?.length
-        ? yAxisLabelTexts[noOfSections - i] ?? value.toString()
+        ? yAxisLabelTexts[startIndex - i] ?? value.toString()
         : value.toString(),
     });
   }


### PR DESCRIPTION
This is a fix for the issue discussed in: https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/364.

It should be possible to set `yAxisLabelTexts` to e.g `['-60.0', '-45.0', '-30.0', '-15.0', '0.0', '15.0', '30.0', '45.0', '60.0']` and have the correct labels rendered on the y-axis. Maybe it should be added to the documentation how to enter yAxisLabelTexts including negative values?

I'm not sure how this will work together with the newly added `secondaryYAxis`.