### PR TITLE
fix: exposed the scrollEventThrottle as a prop

### DIFF
--- a/src/Components/BarAndLineChartsWrapper/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/index.tsx
@@ -76,6 +76,8 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
     pointerIndex,
     pointerX,
     pointerY,
+
+    scrollEventThrottle,
   } = props;
 
   let yAxisAtTop = rtl ? !props.yAxisAtTop : props.yAxisAtTop;
@@ -240,6 +242,7 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
     totalWidth,
     barWidth,
     labelsExtraHeight,
+    scrollEventThrottle,
   };
   const extendedContainerHeight = containerHeight + 10;
   const containerHeightIncludingBelowXAxis =
@@ -322,6 +325,9 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
         ? renderHorizSections(horizSectionProps)
         : null}
       <ScrollView
+        scrollEventThrottle={
+          props.scrollEventThrottle ? props.scrollEventThrottle : 16
+        }
         horizontal
         ref={scrollRef}
         style={[

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -205,4 +205,6 @@ export type BarAndLineChartsWrapperTypes = {
   pointerIndex: number;
   pointerX: number;
   pointerY: number;
+
+  scrollEventThrottle: number;
 };


### PR DESCRIPTION
I keep getting the log: 

'You specified onScroll on a but not scrollEventThrottle. You will only receive one event. Using 16 you get all the events but be aware that it may cause frame drops, use a bigger number if you don't need as much precision.'
