### PR TITLE
Feat/add rtl support to line chart

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -47,6 +47,8 @@ import {
 import BarAndLineChartsWrapper from '../Components/BarAndLineChartsWrapper';
 import {LineChartPropsType, itemType} from './types';
 import {BarAndLineChartsWrapperTypes} from '../utils/types';
+import {StripAndLabel} from '../Components/common/StripAndLabel';
+import {Pointer} from '../Components/common/Pointer';
 
 let initialData: Array<itemType> | null = null;
 let animations: Array<any> = [];

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -14,6 +14,7 @@ import {
   Dimensions,
   Platform,
   ColorValue,
+  I18nManager,
 } from 'react-native';
 import {styles} from './styles';
 import Svg, {
@@ -46,8 +47,6 @@ import {
 import BarAndLineChartsWrapper from '../Components/BarAndLineChartsWrapper';
 import {LineChartPropsType, itemType} from './types';
 import {BarAndLineChartsWrapperTypes} from '../utils/types';
-import {StripAndLabel} from '../Components/common/StripAndLabel';
-import {Pointer} from '../Components/common/Pointer';
 
 let initialData: Array<itemType> | null = null;
 let animations: Array<any> = [];
@@ -1636,6 +1635,7 @@ export const LineChart = (props: LineChartPropsType) => {
       const currentStripWidth = item.stripWidth ?? stripWidth;
       const currentStripOpacity = item.stripOpacity ?? stripOpacity;
       const currentStripColor = item.stripColor || stripColor;
+      const position=I18nManager.isRTL ?  "right" :"left";
 
       return (
         <Fragment key={index}>
@@ -1696,8 +1696,9 @@ export const LineChart = (props: LineChartPropsType) => {
                       height: dataPointsHeight,
                       width: dataPointsWidth,
                       top: getYOrSecondaryY(item.value),
-                      left: initialSpacing - dataPointsWidth + spacing * index,
-                    },
+                      [position]: initialSpacing - dataPointsWidth + spacing * index,
+                      transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+                  },
                   ]}>
                   {customDataPoint()}
                 </View>
@@ -2405,6 +2406,7 @@ export const LineChart = (props: LineChartPropsType) => {
             (props.overflowBottom ?? dataPointsRadius1),
           width: totalWidth,
           zIndex: zIndex,
+          transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
         }}>
         {lineSvgComponent(
           points,
@@ -2669,6 +2671,7 @@ export const LineChart = (props: LineChartPropsType) => {
             (props.overflowBottom ?? dataPointsRadius1),
           width: animatedWidth,
           zIndex: zIndex,
+          transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
           // backgroundColor: 'wheat',
         }}>
         {lineSvgComponent(

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1700,7 +1700,7 @@ export const LineChart = (props: LineChartPropsType) => {
                       top: getYOrSecondaryY(item.value),
                       [position]: initialSpacing - dataPointsWidth + spacing * index,
                       transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
-                  },
+                    },
                   ]}>
                   {customDataPoint()}
                 </View>

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1637,7 +1637,7 @@ export const LineChart = (props: LineChartPropsType) => {
       const currentStripWidth = item.stripWidth ?? stripWidth;
       const currentStripOpacity = item.stripOpacity ?? stripOpacity;
       const currentStripColor = item.stripColor || stripColor;
-      const position=I18nManager.isRTL ?  "right" :"left";
+      const position= I18nManager.isRTL ?  "right" :"left";
 
       return (
         <Fragment key={index}>


### PR DESCRIPTION
add RTL support to LineChart
both x, y axis will follow direction correctly but the content of the chart it self will not and also if we are using focusedCustomDataPoint for the tooltip of each item it will appear in different position


Arabic language written from right to left 
use this data for English

const dataEN= [
  {
    Month: "Jan",
    Performance: 189
  },
  {
    Month: "Feb",
    Performance: 177,
  },
  {
    Month: "Mar",
    Performance: 183,
  },
  {
    Month: "Apr",
    Performance: 187,
  }]. 
and this in Arabic version const dataAR= [
  {
    Month: "يناير",
    Performance: 189
  },
  {
    Month: "فبراير",
    Performance: 177,
  },
  {
    Month: "مارس",
    Performance: 183,
  },
  {
    Month: "ابريل",
    Performance: 187,
  }]

note  1-you will need to run the line chart  with english first then switch to RTL direction to see the issue .
use this line (    I18nManager.forceRTL(!I18nManager.isRTL)  )  to switch from  left to right  direction (used by languages like English ) and  to switch from right to left  direction (used by languages like Arabic ) 