### PR TITLE
Fix: Bar chart -> Support mix of positive + negative values

### DIFF
--- a/src/BarChart/RenderStackBars.tsx
+++ b/src/BarChart/RenderStackBars.tsx
@@ -136,6 +136,7 @@ const RenderStackBars = (props: Props) => {
   }
   const disablePress = props.disablePress || false;
   const renderLabel = (label: String, labelTextStyle: any) => {
+    const lowestBarPosition = getLowestPosition();
     return (
       <View
         style={[
@@ -143,7 +144,9 @@ const RenderStackBars = (props: Props) => {
             width:
               (item.stacks[0].barWidth || props.barWidth || 30) + spacing / 2,
             position: 'absolute',
-            bottom: rotateLabel ? -40 : -6 - xAxisTextNumberOfLines * 18,
+            bottom: rotateLabel
+              ? -40
+              : -6 - xAxisTextNumberOfLines * 18 + lowestBarPosition,
           },
           rotateLabel
             ? props.horizontal
@@ -187,6 +190,10 @@ const RenderStackBars = (props: Props) => {
       }
     }
     return position;
+  };
+
+  const getLowestPosition = () => {
+    return item.stacks.map((_, index) => getPosition(index)).sort()?.[0] || 0;
   };
 
   const getBarHeight = (value: number, marginBottom?: number) => {
@@ -315,7 +322,6 @@ const RenderStackBars = (props: Props) => {
                 borderRadius ??
                 stackBorderBottomRightRadius ??
                 stackBorderRadius,
-              // overflow: 'hidden',
             },
           ]}>
           {item.stacks.map((stackItem, index) => {

--- a/src/BarChart/RenderStackBars.tsx
+++ b/src/BarChart/RenderStackBars.tsx
@@ -193,7 +193,11 @@ const RenderStackBars = (props: Props) => {
   };
 
   const getLowestPosition = () => {
-    return item.stacks.map((_, index) => getPosition(index)).sort()?.[0] || 0;
+    return (
+      item.stacks
+        .map((_, index) => getPosition(index))
+        .sort((a, b) => a - b)?.[0] || 0
+    );
   };
 
   const getBarHeight = (value: number, marginBottom?: number) => {

--- a/src/BarChart/RenderStackBars.tsx
+++ b/src/BarChart/RenderStackBars.tsx
@@ -153,8 +153,8 @@ const RenderStackBars = (props: Props) => {
               ? {transform: [{rotate: '330deg'}]}
               : {transform: [{rotate: '60deg'}]}
             : props.horizontal
-              ? {transform: [{rotate: '-90deg'}]}
-              : {},
+            ? {transform: [{rotate: '-90deg'}]}
+            : {},
         ]}>
         {item.labelComponent ? (
           item.labelComponent()

--- a/src/BarChart/RenderStackBars.tsx
+++ b/src/BarChart/RenderStackBars.tsx
@@ -150,8 +150,8 @@ const RenderStackBars = (props: Props) => {
               ? {transform: [{rotate: '330deg'}]}
               : {transform: [{rotate: '60deg'}]}
             : props.horizontal
-            ? {transform: [{rotate: '-90deg'}]}
-            : {},
+              ? {transform: [{rotate: '-90deg'}]}
+              : {},
         ]}>
         {item.labelComponent ? (
           item.labelComponent()
@@ -315,7 +315,7 @@ const RenderStackBars = (props: Props) => {
                 borderRadius ??
                 stackBorderBottomRightRadius ??
                 stackBorderRadius,
-              overflow: 'hidden',
+              // overflow: 'hidden',
             },
           ]}>
           {item.stacks.map((stackItem, index) => {

--- a/src/BarChart/index.tsx
+++ b/src/BarChart/index.tsx
@@ -358,11 +358,11 @@ export const BarChart = (props: BarChartPropsType) => {
           const currentValue = props.lineData
             ? props.lineData[i].value
             : props.stackData
-              ? props.stackData[i].stacks.reduce(
-                  (total, item) => total + item.value,
-                  0,
-                )
-              : data[i].value;
+            ? props.stackData[i].stacks.reduce(
+                (total, item) => total + item.value,
+                0,
+              )
+            : data[i].value;
           pp +=
             'L' +
             getXForLineInBar(
@@ -413,11 +413,11 @@ export const BarChart = (props: BarChartPropsType) => {
           const currentValue = props.lineData
             ? props.lineData[i].value
             : props.stackData
-              ? props.stackData[i].stacks.reduce(
-                  (total, item) => total + item.value,
-                  0,
-                )
-              : data[i].value;
+            ? props.stackData[i].stacks.reduce(
+                (total, item) => total + item.value,
+                0,
+              )
+            : data[i].value;
           p1Array.push([
             getXForLineInBar(
               i,

--- a/src/BarChart/index.tsx
+++ b/src/BarChart/index.tsx
@@ -117,15 +117,21 @@ export const BarChart = (props: BarChartPropsType) => {
     minItem = 0;
   if (props.stackData) {
     props.stackData.forEach(stackItem => {
-      let stackSum = stackItem.stacks.reduce(
-        (acc, stack) => acc + (stack.value ?? 0),
+      const stackSumMax = stackItem.stacks.reduce(
+        (acc, stack) => acc + (stack.value >= 0 ? stack.value : 0),
         0,
       );
-      if (stackSum > maxItem) {
-        maxItem = stackSum;
+      const stackSumMin = stackItem.stacks.reduce(
+        (acc, stack) => acc + (stack.value < 0 ? stack.value : 0),
+        0,
+      );
+
+      if (stackSumMax > maxItem) {
+        maxItem = stackSumMax;
       }
-      if (stackSum < minItem) {
-        minItem = stackSum;
+
+      if (stackSumMin < minItem) {
+        minItem = stackSumMin;
       }
       totalWidth +=
         (stackItem.stacks[0].barWidth ??
@@ -352,11 +358,11 @@ export const BarChart = (props: BarChartPropsType) => {
           const currentValue = props.lineData
             ? props.lineData[i].value
             : props.stackData
-            ? props.stackData[i].stacks.reduce(
-                (total, item) => total + item.value,
-                0,
-              )
-            : data[i].value;
+              ? props.stackData[i].stacks.reduce(
+                  (total, item) => total + item.value,
+                  0,
+                )
+              : data[i].value;
           pp +=
             'L' +
             getXForLineInBar(
@@ -407,11 +413,11 @@ export const BarChart = (props: BarChartPropsType) => {
           const currentValue = props.lineData
             ? props.lineData[i].value
             : props.stackData
-            ? props.stackData[i].stacks.reduce(
-                (total, item) => total + item.value,
-                0,
-              )
-            : data[i].value;
+              ? props.stackData[i].stacks.reduce(
+                  (total, item) => total + item.value,
+                  0,
+                )
+              : data[i].value;
           p1Array.push([
             getXForLineInBar(
               i,

--- a/src/Components/BarAndLineChartsWrapper/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/index.tsx
@@ -395,6 +395,7 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
               stepHeight / 2 +
               (50 + xAxisLabelsVerticalShift),
             width: totalWidth - spacing + endSpacing,
+            marginTop: 12,
             paddingLeft: initialSpacing,
             paddingBottom:
               noOfSectionsBelowXAxis * stepHeight + labelsExtraHeight,

--- a/src/Components/BarAndLineChartsWrapper/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/index.tsx
@@ -324,8 +324,8 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
           ? (props.width ? -98 - endSpacing : -75 - endSpacing) -
             difBwWidthHeight
           : props.width
-          ? difBwWidthHeight
-          : difBwWidthHeight - 40) /
+            ? difBwWidthHeight
+            : difBwWidthHeight - 40) /
           2 +
         (yAxisAtTop ? (rtl ? (props.width ? 12 : 40) : 12) : 52),
     },
@@ -374,8 +374,8 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
                   (props.width ? 20 : 0) -
                   (data[data.length - 1]?.barWidth ?? barWidth ?? 0) / 2
                 : yAxisSide === yAxisSides.RIGHT
-                ? 0
-                : yAxisLabelWidth + yAxisThickness,
+                  ? 0
+                  : yAxisLabelWidth + yAxisThickness,
             position: 'absolute',
             bottom:
               overflowTop +
@@ -395,7 +395,6 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
               stepHeight / 2 +
               (50 + xAxisLabelsVerticalShift),
             width: totalWidth - spacing + endSpacing,
-            marginTop: 12,
             paddingLeft: initialSpacing,
             paddingBottom:
               noOfSectionsBelowXAxis * stepHeight + labelsExtraHeight,

--- a/src/Components/BarAndLineChartsWrapper/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/index.tsx
@@ -324,8 +324,8 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
           ? (props.width ? -98 - endSpacing : -75 - endSpacing) -
             difBwWidthHeight
           : props.width
-            ? difBwWidthHeight
-            : difBwWidthHeight - 40) /
+          ? difBwWidthHeight
+          : difBwWidthHeight - 40) /
           2 +
         (yAxisAtTop ? (rtl ? (props.width ? 12 : 40) : 12) : 52),
     },
@@ -374,8 +374,8 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
                   (props.width ? 20 : 0) -
                   (data[data.length - 1]?.barWidth ?? barWidth ?? 0) / 2
                 : yAxisSide === yAxisSides.RIGHT
-                  ? 0
-                  : yAxisLabelWidth + yAxisThickness,
+                ? 0
+                : yAxisLabelWidth + yAxisThickness,
             position: 'absolute',
             bottom:
               overflowTop +


### PR DESCRIPTION
A mix of _positive_ and _negative_ values in the stacked bar chart put the whole bar below the x-axis.
This PR allows a stacked bar chart to have _positive_ and _negative_ values in the same stack and renders it correctly.

With this stack data
```typescript
const stacks: stackItemType[] = [
    {
      // Mix of positive and negative values
      label: 'Nov "23',
      stacks: [
        {
          value: 20,
          color: '#35aa0a',
        },
        {
          value: -5,
          color: '#ffa600',
        },
        {
          value: -6,
          color: '#dc25bb',
        },
        {
          value: 10,
          color: '#003f5c',
        },
      ],
    },
    // Only positive values
    {
      label: 'Dez "23',
      stacks: [
        {
          value: 8,
          color: '#35aa0a',
        },
        {
          value: 1,
          color: '#ffa600',
        },
        {
          value: 7,
          color: '#dc25bb',
        },
      ],
    },
    // Only negative values
    {
      label: 'Dez "23',
      stacks: [
        {
          value: -5,
          color: '#35aa0a',
        },
        {
          value: 0,
          color: '#ffa600',
        },
        {
          value: -3,
          color: '#dc25bb',
        },
      ],
    },
  ];
```

### Before
<img width="258" alt="image" src="https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/assets/12933672/e5935c08-8d45-46a4-abe2-26cd0c1db94b">


### After (correct visualization)
* Move negative values below the x-axis
* Move bar labels below the bars
<img width="260" alt="image" src="https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/assets/12933672/8b4efd1e-9473-4843-8484-f2bd61a1b4a4">


connected to https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/261