### PR TITLE
Fix height for PieChart with semiCircle

### DIFF
--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -214,7 +214,7 @@ export const PieChart = (props: propTypes) => {
   return (
     <View
       style={{
-        height: (radius + extraRadiusForFocused) * 2,
+        height: (radius + extraRadiusForFocused) * (props.semiCircle ? 1 : 2),
         width: (radius + extraRadiusForFocused) * 2,
         marginLeft: extraRadiusForFocused * 2,
         marginTop: extraRadiusForFocused * 2,


### PR DESCRIPTION
Hi Abhinandan,
I wanted to bring to your attention a minor issue I encountered when using a PieChart with the `semiCircle` option set to `true`. Currently, it seems that the height of the semicircular pie chart is calculated as if it were a full pie chart, which can lead to suboptimal visualization. This is what I mean:

![image](https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/assets/124571598/d51a3ee3-7b32-4b6d-8796-53e41b19c1b2)

I've identified a simple fix and have submitted this Pull Request to address the issue. This is the result:
![image](https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/assets/124571598/7a591340-d8e2-4c30-a4c9-1f84a9e2df73)

Thank you.

Mauro