### PR TITLE
Fix RTL reverse data

### DIFF
--- a/src/Components/BarAndLineChartsWrapper/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/index.tsx
@@ -1,5 +1,5 @@
 import React, {Fragment, useEffect} from 'react';
-import {View, ScrollView, StyleSheet} from 'react-native';
+import {View, ScrollView, StyleSheet, I18nManager} from 'react-native';
 import {renderHorizSections} from './renderHorizSections';
 import RenderLineInBarChart from './renderLineInBarChart';
 import RenderVerticalLines from './renderVerticalLines';
@@ -166,12 +166,15 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
               (50 + xAxisLabelsVerticalShift),
             width: Math.max(
               props.width ?? 0,
-              totalWidth - spacing + endSpacing,
+              I18nManager.isRTL
+                ? totalWidth + endSpacing
+                : totalWidth - spacing + endSpacing,
             ),
             paddingLeft: initialSpacing,
             paddingBottom:
               noOfSectionsBelowXAxis * stepHeight + labelsExtraHeight,
             alignItems: 'flex-end',
+            flexDirection: I18nManager.isRTL ? 'row-reverse' : 'row',
           },
           !props.width && {width: totalWidth},
         ]}


### PR DESCRIPTION
Currently the data on RTL mode are not displayed from right to left (which i had to add manually with a .reverse())
This causes problems with onStartReached and onEndReached as it consider the end as the start and vice-versa.

- flexDirection: "row-reverse" on ScrollView should do the trick on RTL.
- The other change on the width is because the data with row-reverse goes under te label if spacing is applied to the width of the contentContainerStyle