### PR TITLE
added shiftTextX and shiftTextY for sectionAutoFocus scenario of PieChart

### DIFF
--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -135,6 +135,8 @@ export const PieChart = (props: PieChartPropsType) => {
                     props.data[selectedIndex].strokeWidth || undefined,
                   gradientCenterColor:
                     props.data[selectedIndex].gradientCenterColor || undefined,
+                  shiftTextX: props.data[selectedIndex].shiftTextX || undefined,
+                  shiftTextY: props.data[selectedIndex].shiftTextY || undefined
                 },
                 {
                   value: total - props.data[selectedIndex].value,


### PR DESCRIPTION

I noticed that the shiftTextX and shiftTextY props were missing in the sectionAutoFocus scenario for the PieChart component. 
This caused a change in text location when focused, especially when the radius was conditionally changed. 
Despite passing values for shiftTextX and shiftTextY, they were not being applied.

To fix this issue, I added and passed the props values of shiftTextX and shiftTextY, which were previously missing.
This ensured that the text location remained consistent with user defined values even when the chart was focused and the radius was dynamically adjusted.