### PR TITLE
fix unwanted re-render text value of focused part in sectionAutoFocus case

### DIFF
--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -105,7 +105,8 @@ export const PieChart = (props: PieChartPropsType) => {
       }}>
       <View style={{position: 'absolute'}}>
         <PieChartMain
-          {...(props.data[selectedIndex] &&
+          {...(props.data.length > 1 &&
+          props.data[selectedIndex] &&
           (props.focusOnPress || props.sectionAutoFocus)
             ? {
                 ...props,

--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import {View} from 'react-native';
 import {PieChartMain} from './main';
-import {PieChartPropsType, pieColors, usePieChart} from 'gifted-charts-core';
+import {
+  PieChartPropsType,
+  pieColors,
+  pieDataItem,
+  usePieChart,
+} from 'gifted-charts-core';
 
 export const PieChart = (props: PieChartPropsType) => {
   const {
@@ -100,7 +105,20 @@ export const PieChart = (props: PieChartPropsType) => {
       }}>
       <View style={{position: 'absolute'}}>
         <PieChartMain
-          {...props}
+          {...(props.data[selectedIndex] &&
+          (props.focusOnPress || props.sectionAutoFocus)
+            ? {
+                ...props,
+                data: props.data.map((item: pieDataItem, index: number) =>
+                  index === selectedIndex
+                    ? {
+                        ...item,
+                        text: undefined,
+                      }
+                    : {...item},
+                ),
+              }
+            : {...props})}
           selectedIndex={selectedIndex}
           setSelectedIndex={setSelectedIndex}
           paddingHorizontal={paddingHorizontal}

--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -110,16 +110,12 @@ export const PieChart = (props: PieChartPropsType) => {
           (props.focusOnPress || props.sectionAutoFocus)
             ? {
                 ...props,
-                data: props.data.map((item: pieDataItem, index: number) =>
-                  index === selectedIndex
-                    ? {
-                        ...item,
-                        text: undefined,
-                      }
-                    : {...item},
-                ),
+                data: props.data.map((item: pieDataItem, index: number) => ({
+                  ...item,
+                  text: index === selectedIndex ? undefined : item.text,
+                })),
               }
-            : {...props})}
+            : props)}
           selectedIndex={selectedIndex}
           setSelectedIndex={setSelectedIndex}
           paddingHorizontal={paddingHorizontal}


### PR DESCRIPTION
Hi,

While implementing the sectionAutoFocus scenario, I found an issue with the text value where the text was rendering multiple times, as seen in the attached screenshot. It is visible only for a single-digit value since for a bigger value it is hidden behind.

I'm sharing the fix for the same, where I am clearing out the text value for the focused card fixing the rendering issue.

Thanks for accepting my last PR raised related to the shiftText issue.

issue: 
![20240212_141743](https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/assets/148982717/089e7002-2194-4d10-8133-01bc3c3e44ac)

fix: 
![20240212_141732](https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/assets/148982717/4b7ce23f-3307-4d41-97cb-b60ee2448df7)
