### PR TITLE
Fix - PieChart innerCircleBorderWidth

### DIFF
--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -156,7 +156,7 @@ export const PieChart = (props: PieChartPropsType) => {
             />
           </View>
         )}
-      {renderInnerCircle(innerRadius - inwardExtraLengthForFocused, 0)}
+      {renderInnerCircle(innerRadius - inwardExtraLengthForFocused, innerCircleBorderWidth)}
     </View>
   );
 };


### PR DESCRIPTION
Updated PieChart to pass the innerCircleBorderWidth to all instances of renderInnerCircle(. Current implementation is passing 0 when using (innerRadius-inwardExtraLengthForFocus) which was causing the border to not appear.

It may be that the second renderInnerCircle should be 0, but in that case it might need to be a conditional render if inwardExtraLengthForFocus exists/!=0, because currently it seems to override any innerCircleBorderWidth I provide to 0.