### PR TITLE
Fix: remove all type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gifted-charts",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "The most complete library for Bar, Line, Area, Pie, Donut, Stacked Bar and Population Pyramid charts in React Native. Allows 2D, 3D, gradient, animations and live data updates.",
   "main": "src/index.tsx",
   "files": [

--- a/src/BarChart/RenderBars.tsx
+++ b/src/BarChart/RenderBars.tsx
@@ -4,7 +4,7 @@ import AnimatedThreeDBar from '../Components/AnimatedThreeDBar';
 import Animated2DWithGradient from './Animated2DWithGradient';
 import Cap from '../Components/BarSpecificComponents/cap';
 import BarBackgroundPattern from '../Components/BarSpecificComponents/barBackgroundPattern';
-import LinearGradient from "../Components/common/LinearGradient";
+import LinearGradient from '../Components/common/LinearGradient';
 import {
   getPropsForAnimated2DWithGradient,
   RenderBarsPropsType,
@@ -320,7 +320,10 @@ const RenderBars = (props: RenderBarsPropsType) => {
   const barContent = () => {
     const isBarBelowXaxisAndInvisible =
       item.value < 0 && !noOfSectionsBelowXAxis;
-    const animated2DWithGradient = (noGradient, noAnimation) => (
+    const animated2DWithGradient = (
+      noGradient: boolean,
+      noAnimation: boolean,
+    ) => (
       <Animated2DWithGradient
         {...commonPropsFor2Dand3Dbars}
         animationDuration={animationDuration || 800}

--- a/src/BarChart/index.tsx
+++ b/src/BarChart/index.tsx
@@ -16,7 +16,7 @@ export const BarChart = (props: BarChartPropsType) => {
   const scrollRef = props.scrollRef ?? useRef(null);
   const remainingScrollViewProps = {
     onScroll: (ev: any) => props.onScroll?.(ev),
-    onTouchStart: evt => {
+    onTouchStart: (evt: any) => {
       if (props.renderTooltip) {
         setSelectedIndex(-1);
       }
@@ -134,7 +134,7 @@ export const BarChart = (props: BarChartPropsType) => {
     });
   };
 
-  const renderStripAndLabel = pointerLabelComponent => {
+  const renderStripAndLabel = (pointerLabelComponent: any) => {
     let pointerItemLocal,
       pointerYLocal = pointerY;
 
@@ -197,12 +197,16 @@ export const BarChart = (props: BarChartPropsType) => {
               barWidth / 2;
             setPointerX(z);
             setPointerIndex(factor);
+
             let item, y;
             item = (props.stackData ?? data)[factor];
-            const stackSum = item.stacks?.reduce(
-              (acc, stack) => acc + (stack.value ?? 0),
-              0,
-            );
+            let stackSum = 0;
+            if ('stacks' in item) {
+              stackSum = item.stacks.reduce(
+                (acc: number, stack: any) => acc + (stack.value ?? 0),
+                0,
+              );
+            }
             y =
               containerHeight -
               ((stackSum ?? item.value) * containerHeight) / maxValue -
@@ -241,10 +245,13 @@ export const BarChart = (props: BarChartPropsType) => {
             setPointerX(z);
             setPointerIndex(factor);
             item = (props.stackData ?? data)[factor];
-            const stackSum = item.stacks?.reduce(
-              (acc, stack) => acc + (stack.value ?? 0),
-              0,
-            );
+            let stackSum = 0;
+            if ('stacks' in item) {
+              item.stacks?.reduce(
+                (acc: number, stack: any) => acc + (stack.value ?? 0),
+                0,
+              );
+            }
             y =
               containerHeight -
               ((stackSum ?? item.value) * containerHeight) / maxValue -

--- a/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/index.tsx
@@ -5,7 +5,7 @@ import {renderSpecificVerticalLines} from './renderSpecificVerticalLines';
 import {renderDataPoints} from './renderDataPoints';
 import {renderSpecificDataPoints} from './renderSpecificDataPoints';
 
-const RenderLineInBarChart = props => {
+const RenderLineInBarChart = (props: any) => {
   const {
     yAxisLabelWidth,
     initialSpacing,

--- a/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/renderDataPoints.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/renderDataPoints.tsx
@@ -4,7 +4,7 @@ import {View} from 'react-native';
 import {getXForLineInBar, getYForLineInBar} from 'gifted-charts-core';
 import {Rect, Text as CanvasText, Circle} from 'react-native-svg';
 
-export const renderDataPoints = props => {
+export const renderDataPoints = (props: any) => {
   const {
     data,
     lineConfig,
@@ -22,7 +22,8 @@ export const renderDataPoints = props => {
     const currentBarWidth = item.barWidth || barWidth || 30;
     const customDataPoint = item.customDataPoint || lineConfig.customDataPoint;
     const value =
-      item.value ?? item.stacks.reduce((total, item) => total + item.value, 0);
+      item.value ??
+      item.stacks.reduce((total: number, item: any) => total + item.value, 0);
     if (customDataPoint) {
       return (
         <View

--- a/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/renderSpecificDataPoints.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/renderSpecificDataPoints.tsx
@@ -2,7 +2,7 @@ import React, {Fragment} from 'react';
 import {getXForLineInBar, getYForLineInBar} from 'gifted-charts-core';
 import {Circle, Rect, Text as CanvasText} from 'react-native-svg';
 
-export const renderSpecificDataPoints = props => {
+export const renderSpecificDataPoints = (props: any) => {
   const {
     data,
     barWidth,

--- a/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/renderSpecificVerticalLines.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/renderSpecificVerticalLines.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Rect} from 'react-native-svg';
 
-export const renderSpecificVerticalLines = props => {
+export const renderSpecificVerticalLines = (props: any) => {
   const {
     data,
     barWidth,

--- a/src/Components/BarAndLineChartsWrapper/renderVerticalLines.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderVerticalLines.tsx
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import {chartTypes} from 'gifted-charts-core';
 import {Line, Svg} from 'react-native-svg';
 
-const RenderVerticalLines = props => {
+const RenderVerticalLines = (props: any) => {
   const {
     verticalLinesAr,
     verticalLinesSpacing,
@@ -29,7 +29,7 @@ const RenderVerticalLines = props => {
     xAxisLabelsVerticalShift,
   } = props;
 
-  const getHeightOfVerticalLine = index => {
+  const getHeightOfVerticalLine = (index: number) => {
     if (verticalLinesUptoDataPoint) {
       if (index < data.length) {
         return (
@@ -107,8 +107,8 @@ const RenderVerticalLines = props => {
             (chartType === chartTypes.BAR
               ? totalSpacing - 1
               : verticalLinesSpacing
-              ? verticalLinesSpacing * (index + 1)
-              : index * spacing + (initialSpacing - 2));
+                ? verticalLinesSpacing * (index + 1)
+                : index * spacing + (initialSpacing - 2));
 
           return (
             <Line

--- a/src/Components/BarSpecificComponents/barBackgroundPattern.tsx
+++ b/src/Components/BarSpecificComponents/barBackgroundPattern.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Svg, {Defs, Rect} from 'react-native-svg';
 
-const BarBackgroundPattern = props => {
+const BarBackgroundPattern = (props: any) => {
   const {
     barBackgroundPatternFromItem,
     barBackgroundPatternFromProps,
@@ -10,20 +10,20 @@ const BarBackgroundPattern = props => {
   } = props;
   return (
     <Svg>
-        <Defs>
-            {barBackgroundPatternFromItem
-            ? barBackgroundPatternFromItem()
-            : barBackgroundPatternFromProps()}
-        </Defs>
-        <Rect
-            stroke="transparent"
-            x="1"
-            y="1"
-            width="100%"
-            height="100%"
-            fill={`url(#${patternIdFromItem ?? patternIdFromProps})`}
-        />
-        </Svg>
+      <Defs>
+        {barBackgroundPatternFromItem
+          ? barBackgroundPatternFromItem()
+          : barBackgroundPatternFromProps()}
+      </Defs>
+      <Rect
+        stroke="transparent"
+        x="1"
+        y="1"
+        width="100%"
+        height="100%"
+        fill={`url(#${patternIdFromItem ?? patternIdFromProps})`}
+      />
+    </Svg>
   );
 };
 

--- a/src/Components/BarSpecificComponents/cap.tsx
+++ b/src/Components/BarSpecificComponents/cap.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {View} from 'react-native';
 import {BarDefaults} from 'gifted-charts-core';
 
-const Cap = props => {
+const Cap = (props: any) => {
   const {
     capThicknessFromItem,
     capThicknessFromProps,

--- a/src/Components/common/LinearGradient.tsx
+++ b/src/Components/common/LinearGradient.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import {ViewStyle} from "react-native";
 
 type LinearGradientProps = {
-  style?: ViewStyle;
-  start?: { x: number, y: number };
-  end?: { x: number, y: number };
+  style?: any;
+  start?: {x: number; y: number};
+  end?: {x: number; y: number};
   colors: string[];
-}
+  children?: any;
+};
 
 let LinearGradient: React.FC<LinearGradientProps>;
 
@@ -19,7 +19,7 @@ try {
     LinearGradient = require('expo-linear-gradient').LinearGradient;
   } catch (e) {
     throw new Error(
-      'Gradient package was not found. Make sure "react-native-linear-gradient" or "expo-linear-gradient" is installed'
+      'Gradient package was not found. Make sure "react-native-linear-gradient" or "expo-linear-gradient" is installed',
     );
   }
 }

--- a/src/Components/common/Pointer.tsx
+++ b/src/Components/common/Pointer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 
-export const Pointer = props => {
+export const Pointer = (props: any) => {
   const {
     pointerX,
     pointerYLocal,

--- a/src/Components/common/StripAndLabel.tsx
+++ b/src/Components/common/StripAndLabel.tsx
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import Svg, {Line} from 'react-native-svg';
 import {getTopAndLeftForStripAndLabel} from 'gifted-charts-core';
 
-export const StripAndLabel = props => {
+export const StripAndLabel = (props: any) => {
   const {
     pointerX,
     pointerLabelWidth,

--- a/src/LineChart/LineChartBicolor.tsx
+++ b/src/LineChart/LineChartBicolor.tsx
@@ -190,7 +190,7 @@ export const LineChartBicolor = (props: LineChartBicolorPropsType) => {
     outputRange: [0, totalWidth],
   });
 
-  const onStripPress = (item, index) => {
+  const onStripPress = (item: any, index: number) => {
     setSelectedIndex(index);
     if (props.onFocus) {
       props.onFocus(item, index);
@@ -198,16 +198,16 @@ export const LineChartBicolor = (props: LineChartBicolorPropsType) => {
   };
 
   const renderDataPoints = (
-    dataForRender,
-    dataPtsShape,
-    dataPtsWidth,
-    dataPtsHeight,
-    dataPtsColor,
-    dataPtsRadius,
-    textColor,
-    textFontSize,
-    startIndex,
-    endIndex,
+    dataForRender: any,
+    dataPtsShape: any,
+    dataPtsWidth: any,
+    dataPtsHeight: any,
+    dataPtsColor: any,
+    dataPtsRadius: any,
+    textColor: any,
+    textFontSize: any,
+    startIndex: number,
+    endIndex: number,
   ) => {
     return dataForRender.map((item: bicolorLineDataItem, index: number) => {
       if (index < startIndex || index > endIndex) return null;
@@ -495,7 +495,7 @@ export const LineChartBicolor = (props: LineChartBicolorPropsType) => {
         strokeDashArray.length === 2 &&
         typeof strokeDashArray[0] === 'number' &&
         typeof strokeDashArray[1] === 'number'
-          ? pointsArray.map((points, index) => (
+          ? pointsArray.map((points: any, index: number) => (
               <Path
                 key={index}
                 d={points.points}
@@ -505,7 +505,7 @@ export const LineChartBicolor = (props: LineChartBicolorPropsType) => {
                 strokeDasharray={strokeDashArray}
               />
             ))
-          : pointsArray.map((points, index) => {
+          : pointsArray.map((points: any, index: number) => {
               return (
                 <Path
                   key={index}

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -405,10 +405,10 @@ export const LineChart = (props: LineChartPropsType) => {
   useEffect(() => {
     decreaseWidth();
     labelsAppear();
-    widthValuesFromSet?.forEach((item, index) => {
+    widthValuesFromSet?.forEach((item: any, index: number) => {
       setTimeout(
         () => {
-          decreaseWidthsFromSet?.[index]?.();
+          decreaseWidthsFromSet();
         },
         animateTogether ? 0 : animationDuration * index,
       );
@@ -546,7 +546,7 @@ export const LineChart = (props: LineChartPropsType) => {
     outputRange: [0, totalWidth],
   });
 
-  const onStripPress = (item, index) => {
+  const onStripPress = (item: any, index: number) => {
     setSelectedIndex(index);
     if (props.onFocus) {
       props.onFocus(item, index);
@@ -554,20 +554,20 @@ export const LineChart = (props: LineChartPropsType) => {
   };
 
   const renderDataPoints = (
-    hideDataPoints,
-    dataForRender,
-    originalDataFromProps,
-    dataPtsShape,
-    dataPtsWidth,
-    dataPtsHeight,
-    dataPtsColor,
-    dataPtsRadius,
-    textColor,
-    textFontSize,
-    startIndex,
-    endIndex,
-    isSecondary,
-    showValuesAsDataPointsText,
+    hideDataPoints: any,
+    dataForRender: any,
+    originalDataFromProps: any,
+    dataPtsShape: any,
+    dataPtsWidth: any,
+    dataPtsHeight: any,
+    dataPtsColor: any,
+    dataPtsRadius: any,
+    textColor: any,
+    textFontSize: any,
+    startIndex: any,
+    endIndex: any,
+    isSecondary: any,
+    showValuesAsDataPointsText: any,
   ) => {
     const getYOrSecondaryY = isSecondary ? getSecondaryY : getY;
     return dataForRender.map((item: lineDataItem, index: number) => {
@@ -890,6 +890,7 @@ export const LineChart = (props: LineChartPropsType) => {
           pointerConfig?.secondaryPointerColor || pointerColor;
         break;
     }
+    if (!pointerYLocal) return;
 
     return Pointer({
       pointerX,
@@ -1013,11 +1014,11 @@ export const LineChart = (props: LineChartPropsType) => {
     endOpacity: number,
     strokeDashArray: Array<number> | undefined | null,
     showArrow: boolean,
-    arrowPoints,
-    arrowStrokeWidth,
-    arrowStrokeColor,
-    arrowFillColor,
-    key,
+    arrowPoints: any,
+    arrowStrokeWidth: any,
+    arrowStrokeColor: any,
+    arrowFillColor: any,
+    key: any,
   ) => {
     if (!points) return null;
     const isCurved = points.includes('C');
@@ -1255,7 +1256,7 @@ export const LineChart = (props: LineChartPropsType) => {
     );
   };
 
-  const activatePointers = x => {
+  const activatePointers = (x: number) => {
     let factor = (x - initialSpacing) / spacing;
     factor = Math.round(factor);
     factor = Math.min(factor, (data0 ?? data).length - 1);
@@ -1349,11 +1350,11 @@ export const LineChart = (props: LineChartPropsType) => {
     startOpacity: number,
     endOpacity: number,
     strokeDashArray: Array<number> | undefined | null,
-    showArrow,
-    arrowPoints,
-    arrowStrokeWidth,
-    arrowStrokeColor,
-    arrowFillColor,
+    showArrow: any,
+    arrowPoints: any,
+    arrowStrokeWidth: any,
+    arrowStrokeColor: any,
+    arrowFillColor: any,
     key?: number,
   ) => {
     return (
@@ -1534,11 +1535,11 @@ export const LineChart = (props: LineChartPropsType) => {
     startOpacity: number,
     endOpacity: number,
     strokeDashArray: Array<number> | undefined | null,
-    showArrow,
-    arrowPoints,
-    arrowStrokeWidth,
-    arrowStrokeColor,
-    arrowFillColor,
+    showArrow: any,
+    arrowPoints: any,
+    arrowStrokeWidth: any,
+    arrowStrokeColor: any,
+    arrowFillColor: any,
     key?: number,
   ) => {
     return (

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1334,6 +1334,7 @@ export const LineChart = (props: LineChartPropsType) => {
           (pointerRadius || pointerHeight / 2) +
           10;
         setSecondaryPointerY(y);
+        // @ts-ignore
         setSecondaryPointerItem(item);
       }
     }
@@ -1463,6 +1464,7 @@ export const LineChart = (props: LineChartPropsType) => {
                 (pointerRadius || pointerHeight / 2) +
                 10;
               setSecondaryPointerY(y);
+              // @ts-ignore
               setSecondaryPointerItem(item);
             }
           }
@@ -1648,8 +1650,9 @@ export const LineChart = (props: LineChartPropsType) => {
                 (item.value * containerHeight) / maxValue -
                 (pointerRadius || pointerHeight / 2) +
                 10;
+              // @ts-ignore
               setSecondaryPointerY(y);
-              setSecondaryPointerItem(item);
+              if (item) setSecondaryPointerItem(item);
             }
           }
         }}

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1650,9 +1650,10 @@ export const LineChart = (props: LineChartPropsType) => {
                 (item.value * containerHeight) / maxValue -
                 (pointerRadius || pointerHeight / 2) +
                 10;
-              // @ts-ignore
+
               setSecondaryPointerY(y);
-              if (item) setSecondaryPointerItem(item);
+              // @ts-ignore
+              setSecondaryPointerItem(item);
             }
           }
         }}

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1463,7 +1463,7 @@ export const LineChart = (props: LineChartPropsType) => {
                 (pointerRadius || pointerHeight / 2) +
                 10;
               setSecondaryPointerY(y);
-              setSecondaryPointerItem(item);
+              //setSecondaryPointerItem(item);
             }
           }
         }}

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1463,7 +1463,7 @@ export const LineChart = (props: LineChartPropsType) => {
                 (pointerRadius || pointerHeight / 2) +
                 10;
               setSecondaryPointerY(y);
-              //setSecondaryPointerItem(item);
+              setSecondaryPointerItem(item);
             }
           }
         }}

--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -29,7 +29,10 @@ export const PieChart = (props: PieChartPropsType) => {
     paddingVertical,
   } = usePieChart(props);
 
-  const renderInnerCircle = (innerRadius, innerCircleBorderWidth) => {
+  const renderInnerCircle = (
+    innerRadius: number,
+    innerCircleBorderWidth: number,
+  ) => {
     if (props.centerLabelComponent || (donut && !isDataShifted)) {
       return (
         <View


### PR DESCRIPTION
After using this library, our project is failing because if the type errors in this library. This PR fixes all the errors, generally just by adding type `any` (or type `number` where it's obviously a number).