### PR TITLE
fix: PieChart: Make paths pressable on Android

### DIFF
--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -119,6 +119,7 @@ export const PieChart = (props: PieChartPropsType) => {
               position: 'absolute',
               top: -extraRadiusForFocused,
               left: -extraRadiusForFocused,
+              zIndex: -1,
             }}>
             <PieChartMain
               {...props}


### PR DESCRIPTION
Related to https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/564

The `PieChart` on Android didn't call `onPress` when providing the prop `focusOnPress` or `sectionAutoFocus`.
Probably because the focused/bigger PieChart was covering the main pie chart.

This change fixes this for me and onPress will be called on iOS + Android.


Please test before merging :) 