### PR TITLE
Export DataSet type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,4 +22,5 @@ export {
   ruleTypes,
   yAxisSides,
   EdgePosition,
+  DataSet,
 } from 'gifted-charts-core';


### PR DESCRIPTION
exporting the DataSet type helps allows proper typing of data being used to created charts using the `dataSet` prop.