### PR TITLE
Fix crash Error: AnimatedValue: Attempting to set value to undefined

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -54,7 +54,9 @@ export const LineChart = (props: LineChartPropsType) => {
 
   if (!initialData) {
     initialData = props.dataSet?.[0]?.data ?? props.data ?? [];
-    animations = initialData.map(item => new Animated.Value(item.value));
+    animations = initialData
+      .filter(item => item.value)
+      .map(item => new Animated.Value(item.value));
   }
 
   const {


### PR DESCRIPTION
<img width="641" alt="image" src="https://github.com/user-attachments/assets/668503d0-dc10-4876-90c4-a5e06fc2597c">
Hi @Abhinandan-Kushwaha, 
to continue this [PR](https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/pull/644)

At initialData = props.dataSet?.[0]?.data ?? props.data ?? [];
with initialData result
[{ "dataPointLabelComponent": [Function anonymous], "dataPointLabelShiftX": 75, "focusedDataPointColor": "rgba(60, 121, 245, 1)", "focusedDataPointRadius": 4, "label": "4", "value": 70.88 }, { "label": "5", "value": null }, { "dataPointLabelComponent": [Function anonymous], "dataPointLabelShiftX": 75, "focusedDataPointColor": "rgba(60, 121, 245, 1)", "focusedDataPointRadius": 4, "label": "6", "value": 70.88 }, { "dataPointLabelComponent": [Function anonymous], "dataPointLabelShiftX": 75, "focusedDataPointColor": "rgba(60, 121, 245, 1)", "focusedDataPointRadius": 4, "label": "7", "value": 70.88 }, { "dataPointLabelComponent": [Function anonymous], "dataPointLabelShiftX": 75, "focusedDataPointColor": "rgba(60, 121, 245, 1)", "focusedDataPointRadius": 4, "label": "8", "value": 70.88 }, { "dataPointLabelComponent": [Function anonymous], "dataPointLabelShiftX": 75, "focusedDataPointColor": "rgba(60, 121, 245, 1)", "focusedDataPointRadius": 4, "label": "9", "value": 70.88 }, { "dataPointLabelComponent": [Function anonymous], "dataPointLabelShiftX": 75, "focusedDataPointColor": "rgba(60, 121, 245, 1)", "focusedDataPointRadius": 4, "label": "10", "value": 70.88 }, { "dataPointLabelComponent": [Function anonymous], "dataPointLabelShiftX": 75, "focusedDataPointColor": "rgba(60, 121, 245, 1)", "focusedDataPointRadius": 4, "label": "23", "value": 70.88 }, { "label": "24", "value": null }]

It led to this crash above the first time we initiated chart with initial data

