### PR TITLE
Add labelWidth prop to stacked bar charts

### DIFF
--- a/src/BarChart/RenderStackBars.tsx
+++ b/src/BarChart/RenderStackBars.tsx
@@ -77,7 +77,12 @@ const RenderStackBars = (props: StackedBarChartPropsType) => {
         style={[
           {
             width:
-              (item.stacks[0].barWidth || props.barWidth || 30) + spacing / 2,
+              (item.labelWidth ||
+                props.labelWidth ||
+                item.stacks[0].barWidth ||
+                props.barWidth ||
+                30) +
+              spacing / 2,
             position: 'absolute',
             bottom: autoShiftLabelsForNegativeStacks
               ? -6 - xAxisTextNumberOfLines * 18 + lowestBarPosition


### PR DESCRIPTION
This PR depends on https://github.com/Abhinandan-Kushwaha/gifted-charts-core/pull/36

Follows the established pattern for bar charts to allow customizing label width on stacked bar charts.

This is needed to fix my stacked bar chart, where two stacked bars are close together under one label:

![image](https://github.com/user-attachments/assets/65fb49ed-d5a9-48f2-a61d-aa84ed0ca20a)

Labels with `labelWidth` look like this:

![image](https://github.com/user-attachments/assets/d398ad1a-ce53-4443-8d8c-21932ca01dfb)

