### PR TITLE
Fix of LineChart display on Safari (iPhone)

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1211,7 +1211,7 @@ export const LineChart = (props: LineChartPropsType) => {
       lineSvgPropsOuter.strokeDasharray = strokeDashArray;
     }
     return (
-      <Svg onPress={props.onBackgroundPress}>
+      <Svg style={{ overflow: 'visible' }} onPress={props.onBackgroundPress}>
         {lineGradient && getLineGradientComponent()}
         {points.includes(SEGMENT_START) || points.includes(RANGE_ENTER) ? (
           ar.map((item, index) => {


### PR DESCRIPTION
This is fix that I found to the issue I filed recently: #782
As I mentioned there are some differences in displaying `<svg>` element on Safari when no `viewport` prop specified, and originally LineChart was displayed like this in my [minimal reproduction repo](https://github.com/rodnoycry/safari-charts-bug):

<image src="https://github.com/user-attachments/assets/9afbb6e0-11c7-446c-8873-fc2e32a0c9ec" height="500px" width="auto" />

Deployed example for quick check: https://safari-charts-bug.vercel.app/

As I found out the problem was with method `lineSvgComponent` of `LineChart` component. Original code didn't provide any viewport or size of SVG element:

```tsx
    return (
      <Svg onPress={props.onBackgroundPress}>
```

There was a few options to fix this issue - specify height prop, specify viewport prop, but I decided to apply style with `{ overflow: "visible" }` as in my opinion most universal option. After this changes LineChart started to display as expected:

<image src="https://github.com/user-attachments/assets/f4803a54-ecff-4e3f-8fb5-158acb30d649" height="500px" width="auto" />

Branch of example repo with applied patch: https://github.com/rodnoycry/safari-charts-bug/tree/fixed

Deployed example (you need to copy and paste exact link, as it in preview state of deploy):
https://safari-charts-bug-git-fixed-rodnoycrys-projects.vercel.app/?_vercel_share=soSBCrIc6VDSWWArC7WcvJssXF0AhQr1

