### PR TITLE
Use scrollAnimation when scrolling to index

### DIFF
--- a/src/Components/BarAndLineChartsWrapper/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/index.tsx
@@ -196,6 +196,7 @@ const BarAndLineChartsWrapper = (props: BarAndLineChartsWrapperTypes) => {
                 initialSpacing +
                 ((barWidth ?? 0) + spacing) * scrollToIndex -
                 spacing,
+              animated: scrollAnimation
             });
           }
         }}


### PR DESCRIPTION
Setting scrollAnimation to false in a LineChart does not disable the initial animation for scrollToIndex. I am passing scrollAnimation to `scrollRef.current.scrollTo` so the scrollAnimation is applied for `scrollToIndex`.

Issue: https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/859