### PR TITLE
- fixed and returned -1, in getPointerProp, upon releasing the pointer of a line chart  [issue #854]

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "android": "react-native run-android",
     "build": "rm -rf ./dist && tsc -p . && ./build.sh",
+    "prepare": "npm run build",
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",

--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1537,7 +1537,7 @@ export const LineChart = (props: LineChartPropsType) => {
         onResponderEnd={evt => {
           // console.log('evt...end.......',evt);
           setResponderStartTime(0);
-          // setPointerIndex(-1);
+          setPointerIndex(-1);
           setResponderActive(false);
           if (!persistPointer)
             setTimeout(() => setPointerX(0), pointerVanishDelay);
@@ -1669,7 +1669,7 @@ export const LineChart = (props: LineChartPropsType) => {
         onResponderEnd={evt => {
           // console.log('evt...end.......',evt);
           setResponderStartTime(0);
-          // setPointerIndex(-1);
+          setPointerIndex(-1);
           setResponderActive(false);
           if (!persistPointer)
             setTimeout(() => setPointerX(0), pointerVanishDelay);


### PR DESCRIPTION
https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/854


The lines of code that reset the line chart pointer index to `-1` upon releasing it were commented on. I have uncommented them.

Now, the pointer index is correctly set to `-1 ` when the pointer is released.

I am asking myself why these lines of code were commented on. Was it during testing or was this in conflict with other feature / behavior?

You can directly install the (npm package) branch with the fixes / removed comments  from git using:

`npx npm install git+https://github.com/jeanniton-mnr/react-native-gifted-charts.git`

Best & happy coding!