### PR TITLE
Fix `autoCenterTooltip` property behavior for small tooltips

### DIFF
--- a/src/Components/BarSpecificComponents/tooltip.tsx
+++ b/src/Components/BarSpecificComponents/tooltip.tsx
@@ -48,8 +48,7 @@ const Tooltip = (props: TooltipProps) => {
       onLayout={event => {
         if (!autoCenterTooltip) return;
         const {width} = event.nativeEvent.layout;
-        const shift = (width - barWidth) / 2;
-        if (shift > 0) setLeftShiftTooltipForCentering(shift);
+        setLeftShiftTooltipForCentering((width - barWidth) / 2);
       }}>
       {renderTooltip?.(item, index)}
     </View>


### PR DESCRIPTION
Resolves #913 

For small tooltips shift value is negative and according to the calculations for `left` property its absolute value will be added to `leftSpacing` value resulting in correct tooltip position