### PR TITLE
LineChart - Use totalWidth to show strips beyond the screenWidth

### DIFF
--- a/src/Components/common/StripAndLabel.tsx
+++ b/src/Components/common/StripAndLabel.tsx
@@ -32,6 +32,7 @@ export const StripAndLabel = (props: StripAndLabelProps) => {
     containsNegative,
     horizontalStripConfig,
     screenWidth,
+    width,
   } = props;
 
   const {top, left} = getTopAndLeftForStripAndLabel(props);
@@ -54,7 +55,7 @@ export const StripAndLabel = (props: StripAndLabelProps) => {
             position: 'absolute',
             left: -pointerStripWidth / 4,
             top: containsNegative ? 0 : -pointerYLocal + 8 + xAxisThickness,
-            width: screenWidth,
+            width,
             height: containerHeight,
           }}>
           <Svg>
@@ -94,8 +95,8 @@ export const StripAndLabel = (props: StripAndLabelProps) => {
                   horizontalStripConfig.thickness ?? pointerStripWidth
                 }
                 strokeDasharray={
-                  (pointerConfig?.horizontalStripConfig?.strokeDashArray ??
-                  pointerConfig?.strokeDashArray)
+                  pointerConfig?.horizontalStripConfig?.strokeDashArray ??
+                  pointerConfig?.strokeDashArray
                     ? pointerConfig?.strokeDashArray
                     : ''
                 }


### PR DESCRIPTION
Closes: https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/952

This is already working with datapoints contained within the screenWidth, but if I press datapoints beyond the screenWidth, the strip is not displayed.

## Suggested solution

Use totalWidth instead of screenWidth in the Strip container.

## Videos

### Bug
https://github.com/user-attachments/assets/b34f9625-2d97-40fe-95d9-67286284b6b8

### Bug solved
https://github.com/user-attachments/assets/eb8e8e38-8b0c-4497-aa97-477e9ee19c96


