### PR TITLE
Enhance label customization by passing `label` prop to `labelComponent`

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -560,7 +560,7 @@ export const LineChart = (props: LineChartPropsType) => {
           rotateLabel && {transform: [{rotate: '60deg'}]},
         ]}>
         {labelComponent ? (
-          labelComponent()
+          labelComponent(label)
         ) : (
           <Text
             style={[{textAlign: 'center'}, labelTextStyle]}
@@ -605,7 +605,7 @@ export const LineChart = (props: LineChartPropsType) => {
           rotateLabel && {transform: [{rotate: '60deg'}]},
         ]}>
         {labelComponent ? (
-          labelComponent()
+          labelComponent(label)
         ) : (
           <Text
             style={[{textAlign: 'center'}, labelTextStyle]}


### PR DESCRIPTION
This change allows users to pass the `label` prop directly to the `labelComponent`, enabling external customization of the label rendering. Previously, the `labelComponent` was static and did not accept dynamic input for the label text. With this update, users can now manage the label component and customize its content, style, or behavior outside the `LineChart` component.

This flexibility is useful when users need to apply custom rendering logic or styles to the labels based on their application-specific requirements.

### Changes:
- Modified `labelComponent` to accept the `label` prop as an argument, allowing it to be passed from the parent.
- Updated the rendering logic for both static and animated labels to use the updated `labelComponent` signature.