### PR TITLE
Fix: functionality issue for `toggleFocusOnPress` prop and incorrect color issue for `focusOnPress` prop in `PieChart` component

### DIFF
--- a/src/PieChart/index.tsx
+++ b/src/PieChart/index.tsx
@@ -186,6 +186,7 @@ export const PieChart = (props: PieChartPropsType) => {
           setTouchY={setTouchY}
           tooltipSelectedIndex={tooltipSelectedIndex}
           setTooltipSelectedIndex={setTooltipSelectedIndex}
+          selectedIndex={selectedIndex}
           setSelectedIndex={setSelectedIndex}
           paddingHorizontal={paddingHorizontal}
           paddingVertical={paddingVertical}
@@ -225,6 +226,7 @@ export const PieChart = (props: PieChartPropsType) => {
               initialAngle={startAngle}
               innerRadius={props.innerRadius || radius / 2.5}
               isBiggerPie
+              selectedIndex={selectedIndex}
               setSelectedIndex={setSelectedIndex}
               paddingHorizontal={paddingHorizontal}
               paddingVertical={paddingVertical}

--- a/src/PieChart/main.tsx
+++ b/src/PieChart/main.tsx
@@ -218,7 +218,7 @@ export const PieChartMain = (props: PieChartMainProps) => {
                         : item.strokeWidth || strokeWidth
                   }
                   fill={
-                    props.selectedIndex === index || item.peripheral
+                    item.peripheral
                       ? 'none'
                       : showGradient
                         ? `url(#grad${index})`

--- a/src/PieChart/main.tsx
+++ b/src/PieChart/main.tsx
@@ -222,7 +222,7 @@ export const PieChartMain = (props: PieChartMainProps) => {
                       ? 'none'
                       : showGradient
                         ? `url(#grad${index})`
-                        : item.color || pieColors[index % 9]
+                        : item.color || pieColors[isBiggerPie ? props.selectedIndex ?? 0 % 9 : index % 9]
                   }
                 />
               );


### PR DESCRIPTION
1. `toggleFocusOnPress` functionality issue:
 - Issue: Focused pie section doesn't go out of focus when pressed again.
 - Reason: `selectedIndex` prop is used at few instances in `PieChartMain` component and `getPieChartMainProps` function (`gifted-charts-core`). One of these instances handles `toggleFocusOnPress`. But `selectedIndex` prop was never included in `PieChartMain` component call inside `PieChart` component.
 - Fix: Including the `selectedIndex` prop in `PieChartMain` component call inside `PieChart` component.
2. Incorrect `fill` prop value for focused pie section at index 0:
 - Issue: If pie section at index 0 is focused, then the `fill` prop is set to none for the focused pie section.
 - Fix: Removing the `selectedIndex === index` condition where `fill` prop is set to "none".
3. Incorrect color for focused pie sections at indices other than 0:
 - Issue: When `data` prop doesn't include color property for some values, then the color for the focused pie section belonging to those values is set to the color of pie section at index 0.
 - Fix: Including `selectedIndex` condition for `fill` prop where pie section color is not given.