### PR TITLE
feat: implementation for highlighted/focused mutiple indicies

### DIFF
--- a/docs/BarChart/BarChartProps.md
+++ b/docs/BarChart/BarChartProps.md
@@ -14,7 +14,7 @@
 | onPressOut                   | Function                  | Callback function called on press out of a Bar (takes item and index as parameter)                                                                | null                |
 | focusBarOnPress              | boolean                   | used to focus a bar on press by applying styles defined in focusedBarConfig                                                                       | false               |
 | focusedBarConfig             | FocusedBarConfig          | styles for the focused bar including color, width, opacity, borderRadius etc                                                                      | \_                  |
-| focusedBarIndex              | number                    | index of the initially focused bar, works only when focusBarOnPress is true                                                                       | -1                  |
+| focusedBarIndex              | number|number[]                    | index(or indices) of the initially focused bar(s), works only when focusBarOnPress is true                                                                       | -1                  |
 | maxValue                     | number                    | Maximum value shown in the Y axis                                                                                                                 | 200                 |
 | yAxisOffset                  | number                    | Starting (minimum) value in the Y axis (value at the origin)                                                                                      | 0                   |
 | mostNegativeValue            | number                    | The most negative value shown in the Y axis (to be used only if the data set has negative values too)                                             | \_                  |
@@ -61,7 +61,7 @@
 | topLabelTextStyle            | object                    | text style for the top labels that appear at the top of bars                                                                                      | \_                  |
 | highlightEnabled             | boolean                   | used to highlight a particular Bar on press, by decreasing the opacity of the remaining (setting them to lowlightOpacity)                         | false               |
 | lowlightOpacity              | number                    | the opacity of the un-highlighted bars when one of them is highlighted                                                                            | 0.3                 |
-| highlightedBarIndex          | number                    | the index of the highlighted bar                                                                                                                  | -1                  |
+| highlightedBarIndex          | number|number[]                    | the index(or indices) of the highlighted bar(s)                                                                                                                  | -1                  |
 | onBackgroundPress            | Function                  | Callback function called on pressing the chart body (outside of the bars). Helps ufocus/unselect after focusing/selecting a Bar                   | \_                  |
 
 **Note:** `onBackgroundPress` will not work if pointer feature is used in the chart (using the `pointerConfig` prop.)

--- a/src/BarChart/RenderBars.tsx
+++ b/src/BarChart/RenderBars.tsx
@@ -8,6 +8,11 @@ import {
 } from 'gifted-charts-core';
 import Tooltip from '../Components/BarSpecificComponents/tooltip';
 
+const isIndexSelected = (values: number|number[], idx: number) => {
+  if(Array.isArray(values)) return values.includes(idx)
+  return values === idx
+}
+
 const RenderBars = (props: RenderBarsPropsType) => {
   const {
     item,
@@ -242,10 +247,10 @@ const RenderBars = (props: RenderBarsPropsType) => {
   const barWrapperStyle = [
     {
       // overflow: 'visible',
-      opacity: highlightEnabled
-        ? highlightedBarIndex === -1
-          ? 1
-          : highlightedBarIndex === index
+      opacity: highlightEnabled ?
+          isIndexSelected(highlightedBarIndex, -1)
+          ? 1 :
+            isIndexSelected(highlightedBarIndex, index)
             ? 1
             : lowlightOpacity
         : 1,
@@ -377,7 +382,7 @@ const RenderBars = (props: RenderBarsPropsType) => {
           onPress={() => {
             if (renderTooltip || props.focusBarOnPress || highlightEnabled) {
               if (props.focusedBarIndex === undefined || !props.onPress) {
-                setSelectedIndex(index);
+                setSelectedIndex([index]);
               }
             }
             item.onPress
@@ -404,7 +409,7 @@ const RenderBars = (props: RenderBarsPropsType) => {
           {barContent()}
         </TouchableOpacity>
       )}
-      {renderTooltip && selectedIndex === index && (
+      {renderTooltip && selectedIndex.includes(index) && (
         <Tooltip {...tooltipProps} />
       )}
     </>

--- a/src/BarChart/index.tsx
+++ b/src/BarChart/index.tsx
@@ -18,7 +18,7 @@ export const BarChart = (props: BarChartPropsType) => {
     onScroll: (ev: any) => props.onScroll?.(ev),
     onTouchStart: (evt: any) => {
       if (props.renderTooltip) {
-        setSelectedIndex(-1);
+        setSelectedIndex([-1]);
       }
     },
     bounces: props.bounces,
@@ -326,8 +326,8 @@ export const BarChart = (props: BarChartPropsType) => {
         <Pressable
           style={contentContainerStyle}
           onPress={() => {
-            if (props.highlightEnabled && selectedIndex !== -1)
-              setSelectedIndex(-1);
+            if (props.highlightEnabled && !selectedIndex.includes(-1))
+              setSelectedIndex([-1]);
             if (props.stackHighlightEnabled && selectedStackIndex !== -1) {
               setSelectedStackIndex(-1);
               // props.setHighlightedStackIndex?.(-1)
@@ -343,6 +343,7 @@ export const BarChart = (props: BarChartPropsType) => {
   const renderChart = () => {
     if (stackData) {
       return stackData.map((item, index) => {
+        const {selectedIndex,...stackRestProps} = getPropsCommonForBarAndStack(item,index)
         return (
           <RenderStackBars
             key={index}
@@ -358,7 +359,8 @@ export const BarChart = (props: BarChartPropsType) => {
             selectedStackIndex={selectedStackIndex}
             setSelectedStackIndex={setSelectedStackIndex}
             // highlightedStackIndex={props.highlightedStackIndex??-1}
-            {...getPropsCommonForBarAndStack(item, index)}
+            selectedIndex={selectedIndex[0]}
+            {...stackRestProps}
           />
         );
       });

--- a/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/index.tsx
@@ -33,7 +33,7 @@ const RenderLineInBarChart = (props: LineInBarChartPropsType) => {
 
   const firstBarWidth = data[0].barWidth ?? barWidth;
   const opacity = highlightEnabled
-    ? selectedIndex === -1
+    ? selectedIndex.includes(-1)
       ? 1
       : lowlightOpacity
     : 1;
@@ -47,7 +47,7 @@ const RenderLineInBarChart = (props: LineInBarChartPropsType) => {
     firstBarWidth,
     yAxisLabelWidth,
     spacing,
-    selectedIndex,
+    selectedIndex: selectedIndex[0],
     yAxisOffset,
     opacity,
   };


### PR DESCRIPTION
### What
- make `selectedIndex` an array
- `highlightedBarIndex` can now be an `number[]` or number

Steps to verify
1. Follow example from https://gifted-charts.web.app/barchart/#customised
2. Now pass `highlightedBarIndex={[2,3]}` and `highlightEnabled` prop to `<BarChart />`
3. This should now highlight bars at index 2 and 3

Notes:
- This multiple indices is only limited for BarChart and not others
- Existing workflow should not be affected, since we're also supporting `highlightedBarIndex` and `focusedBarIndex` to be a regular number

Closes: https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/1083