### PR TITLE
feat: add spread to line chart

### DIFF
--- a/docs/LineChart/LineChartProps.md
+++ b/docs/LineChart/LineChartProps.md
@@ -937,6 +937,9 @@ Here is the list of prop names changed in version `1.3.2`-
 | areaGradientId         | string                 | id of the <LinearGradient> (needed along with areaGradientComponent prop)                               | \_            |
 | onChartAreaPress       | Function               | Callback function called on pressing the chart area                                                     | \_            |
 | intersectionAreaConfig | IntersectionAreaConfig | Config object that defines properties for intersection area of data and data2 (1st & 2nd areas)         | \_            |
+| spreadAreaData         | Array<{lower: number; upper: number}> | Array of objects defining lower and upper bounds for each data point to create a spread/band area | \_            |
+| spreadAreaColor        | ColorValue             | Color of the spread area/band                                                                           | 'lightgray'   |
+| spreadAreaOpacity      | number                 | Opacity of the spread area/band                                                                         | 0.3           |
 
 ### IntersectionAreaConfig
 
@@ -947,7 +950,3 @@ type IntersectionAreaConfig {
   fillColor: ColorValue // default: 'white'
 }
 ```
-
-### Example of areaGradientComponent
-
-Same as [example of lineGradientComponent](https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/blob/master/docs/LineChart/LineChartProps.md#an-example-of-linegradientcomponent)


### PR DESCRIPTION
# Add Spread Area/Band Functionality to Line Charts

This PR adds the ability to display spread areas (confidence bands, error bands, etc.) on line charts, providing visual representation of data ranges or uncertainty bounds and addresses #1093. Note that this PR depends on this [PR](<https://github.com/Abhinandan-Kushwaha/gifted-charts-core/pull/86>) on gifted-charts-core. Thanks [@TirelessDev](<https://github.com/TirelessDev>) for helping me with this!

## New Features

### Line Chart Props

| Prop Name | Type | Description | Default |
|-----------|------|-------------|---------|
| `spreadAreaData` | `Array<{lower: number; upper: number}>` | Array of objects defining lower and upper bounds for each data point to create a spread/band area | `undefined` |
| `spreadAreaColor` | `ColorValue` | Color of the spread area/band | `'lightgray'` |
| `spreadAreaOpacity` | `number` | Opacity of the spread area (0-1) | `0.3` |

### Usage Example

```typescript
const chartData = [
  { value: 10 },
  { value: 20 },
  { value: 15 },
  { value: 25 }
];

const spreadData = [
  { lower: 8, upper: 12 },
  { lower: 18, upper: 22 },
  { lower: 13, upper: 17 },
  { lower: 23, upper: 27 }
];

<LineChart
  data={chartData}
  spreadAreaData={spreadData}
  spreadAreaColor="rgba(100, 150, 200, 0.3)"
  spreadAreaOpacity={0.4}
/>
```

### Visual Preview

The spread area creates a filled region between the upper and lower bounds, providing context for data variability or confidence intervals.

<img width="303" alt="Screenshot 2025-06-09 at 9 07 22 PM" src="https://github.com/user-attachments/assets/e71fa409-dd08-43c7-92bd-eae2c5f71c79" />

### Breaking Changes

None - this is a purely additive feature with optional props.