### PR TITLE
fix: Add uniqueId for LineChart area gradient to fix issue in web - multiple color gradients

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1129,12 +1129,13 @@ export const LineChart = (props: LineChartPropsType) => {
     endFillColor: string,
     startOpacity: number,
     endOpacity: number,
+    gradientId?: string,
   ) => {
     return props.areaGradientComponent ? (
       props.areaGradientComponent()
     ) : (
       <LinearGradient
-        id="Gradient"
+        id={gradientId || 'Gradient'}
         x1="0"
         y1="0"
         x2={gradientDirection === 'horizontal' ? '1' : '0'}
@@ -1384,6 +1385,7 @@ export const LineChart = (props: LineChartPropsType) => {
   ) => {
     if (!points) return null;
     const isCurved = points.includes('C') || points.includes('Q');
+    const uniqueId = `Gradient-line-${key}`;
     const isNthAreaChart = !!dataSet
       ? (dataSet[Number(key)].areaChart ?? areaChart)
       : getIsNthAreaChart(key ?? 0);
@@ -1476,6 +1478,7 @@ export const LineChart = (props: LineChartPropsType) => {
             endFillColor,
             startOpacity,
             endOpacity,
+            uniqueId,
           )}
         {isNthAreaChart ? (
           props.interpolateMissingValues === false &&
@@ -1488,7 +1491,7 @@ export const LineChart = (props: LineChartPropsType) => {
               fill={
                 props.areaGradientId
                   ? `url(#${props.areaGradientId})`
-                  : `url(#Gradient)`
+                  : `url(#${uniqueId})`
               }
               stroke={'none'}
               strokeWidth={currentLineThickness || thickness}
@@ -1500,7 +1503,7 @@ export const LineChart = (props: LineChartPropsType) => {
               fill={
                 props.areaGradientId
                   ? `url(#${props.areaGradientId})`
-                  : `url(#Gradient)`
+                  : `url(#${uniqueId})`
               }
               stroke={'none'}
               strokeWidth={currentLineThickness || thickness}


### PR DESCRIPTION
When rendering a chart with multiple Area series, using startFillColor1, startFillColor2, etc., works as expected on Android and iOS. Each Area chart correctly displays its own gradient. However, on the web, as you can see in image attached below, only the first gradient is applied to all series. This happens because the gradient SVG definitions all share the same id ("Gradient"), rather than having unique IDs per Area series.

**Before fix:**
<img width="529" alt="before" src="https://github.com/user-attachments/assets/d5ff433b-63f4-4189-81af-f311c92bb696" />

**After fix:**
<img width="528" alt="after" src="https://github.com/user-attachments/assets/98ea92ff-ba5f-4940-8db4-0ca23bb43c0b" />
