### PR TITLE
fix: Remove background pattern margin

### DIFF
--- a/src/BarChart/RenderStackBars.tsx
+++ b/src/BarChart/RenderStackBars.tsx
@@ -320,8 +320,8 @@ const RenderStackBars = (props: StackedBarChartPropsType) => {
               </Defs>
               <Rect
                 stroke="none"
-                x="1"
-                y="1"
+                x="0"
+                y="0"
                 width="100%"
                 height={totalHeight}
                 fill={`url(#${item.patternId || patternId})`}


### PR DESCRIPTION
Currently a pattern on a bar **doesn't cover the whole** bar.
It leads to a 1px margin to the **top** and to the **left**. 
This PR removed that unwanted margin.

Code for screenshots below:

```typescript
  const data: stackDataItem[] = [
    {
      barBackgroundPattern: DiagonalLinePattern,
      patternId: 'DiagonalLines',
      stacks: [
        {
          value: 110,
          color: '#ff000d', // red
        },
      ],
    },
  ];
  
 <BarChart stackData={data} barWidth={40} spacing={30} />
```


**Before** with red line (visible red bar) visible behind the pattern

<img width="209" alt="image" src="https://github.com/user-attachments/assets/485fcd04-3464-4941-ae8f-832901a6cc74" />


**After** without red line visible
<img width="186" alt="image" src="https://github.com/user-attachments/assets/5801438a-5303-48fd-9139-3ae47e913529" />
