### PR TITLE
fix: use stackData or data for pointerConfig

### DIFF
--- a/src/BarChart/index.tsx
+++ b/src/BarChart/index.tsx
@@ -196,9 +196,10 @@ export const BarChart = (props: BarChartPropsType) => {
   };
 
   const activatePointer = (x: number) => {
+    const chartData = stackData ?? data;
     let factor = (x - initialSpacing - barWidth / 2) / (spacing + barWidth);
     factor = Math.round(factor);
-    factor = Math.min(factor, data.length - 1);
+    factor = Math.min(factor, chartData.length - 1);
     factor = Math.max(factor, 0);
     let z =
       initialSpacing +
@@ -209,7 +210,7 @@ export const BarChart = (props: BarChartPropsType) => {
     setPointerIndex(factor);
 
     let item, y;
-    item = (stackData ?? data)[factor];
+    item = chartData[factor];
     let stackSum = 0;
     if ('stacks' in item) {
       stackSum = item.stacks.reduce(
@@ -343,7 +344,11 @@ export const BarChart = (props: BarChartPropsType) => {
   const renderChart = () => {
     if (stackData) {
       return stackData.map((item, index) => {
-        const {selectedIndex,...stackRestProps} = getPropsCommonForBarAndStack(item,index)
+        const {selectedIndex, ...stackRestProps} = getPropsCommonForBarAndStack(
+          item,
+          index,
+        );
+
         return (
           <RenderStackBars
             key={index}


### PR DESCRIPTION
Previously, when rendering pointerConfig in StackBarChart, the pointer would remain stuck on the first chart bar and wouldn't move across the bars when interacting with them. See screen recording before fix:
https://github.com/user-attachments/assets/b2b96039-be78-4526-ab67-d23be4339286

Now the fix ensures that the stackData.length is correctly taken into account, allowing the pointer to move smoothly across bars as expected. You can see the corrected behavior in the screen recording below:
https://github.com/user-attachments/assets/32db7fd7-ff23-4372-ad91-c40800c18282

Closes https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/1117