### PR TITLE
Fix: Typo correction in LineChartProps.md

### DIFF
--- a/docs/LineChart/LineChartProps.md
+++ b/docs/LineChart/LineChartProps.md
@@ -719,7 +719,7 @@ pointerConfig is an object, when passed as a prop, creates a magical effect. It 
 
 <img src='../../demos/scrollLine.gif' alt='' height=400 width=500/>
 
-To enable such kind of csroll effect, just pass the prop pointerConfig.
+To enable such kind of scroll effect, just pass the prop pointerConfig.
 The pointerConfig object has following fields-
 
 ```ts


### PR DESCRIPTION
This pull request fixes a minor typo in the documentation for the LineChart component.

- Corrected "csroll" to "scroll" in the pointerConfig section.

This change improves the clarity and professionalism of the documentation.