### PR TITLE
fix: support multiline RadarChart labels using <TSpan>

### DIFF
--- a/examples/RadarChart/MultipleLineLabel.tsx
+++ b/examples/RadarChart/MultipleLineLabel.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {View} from 'react-native';
+import {RadarChart} from '../../src/RadarChart';
+
+const MultipleLineLabel = () => {
+  return (
+    <View style={{backgroundColor: 'white', flex: 1}}>
+      <RadarChart
+        chartSize={400}
+        data={[50, 60, 10, 70, 30]}
+        labelConfigArray={[
+          {fontSize: 10},
+          {fontSize: 15},
+          {fontSize: 20},
+          {fontSize: 25},
+        ]}
+        maxValue={100}
+        labels={[
+          'Lorem\nIpsum',
+          'Lorem\nIpsum',
+          'Lorem Ipsum\nLorem Ipsum',
+          'Lorem Ipsum\nLorem Ipsum\nLorem Ipsum',
+          'Lorem Ipsum',
+        ]}
+      />
+    </View>
+  );
+};
+
+export default MultipleLineLabel;

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -53,6 +53,7 @@ import {
   LineChartsWithDataSetCritical,
   PieAndDonutCriticalCharts,
 } from './criticalReview';
+import MultipleLineLabel from './RadarChart/MultipleLineLabel';
 
 const Examples = () => {
   const [selectedFooterButton, setSelectedFooterButton] = useState(0);
@@ -69,6 +70,8 @@ const Examples = () => {
           return 'Line with DataSet & Step';
         case 3:
           return 'Pie & Donut Charts';
+        case 4:
+          return 'Radar Chart';
       }
     };
     return (
@@ -216,6 +219,14 @@ const Examples = () => {
     );
   };
 
+  const RedarCharts = () => {
+    return (
+      <View>
+        <MultipleLineLabel />
+      </View>
+    );
+  };
+
   const SelectedIndexCriticalCharts = () => {
     switch (selectedFooterButton) {
       case 0:
@@ -226,6 +237,8 @@ const Examples = () => {
         return <LineChartsWithDataSetCritical />;
       case 3:
         return <PieAndDonutCriticalCharts />;
+      case 4:
+        return <RedarCharts />;
     }
   };
 
@@ -239,6 +252,8 @@ const Examples = () => {
         return <LineChartsWithDataSet />;
       case 3:
         return <PieAndDonutCharts />;
+      case 4:
+        return <RedarCharts />;
     }
   };
 
@@ -323,6 +338,21 @@ const Examples = () => {
             onPress={() => setSelectedFooterButton(3)}>
             <Text>Pie</Text>
             <Text>Donut</Text>
+          </TouchableOpacity>
+        </View>
+        <View
+          style={[
+            styles.footerButtonContainer,
+            selectedFooterButton === 4 ? {marginTop: -12} : null,
+          ]}>
+          {selectedFooterButton === 4 ? (
+            <View style={styles.connector} />
+          ) : null}
+          <TouchableOpacity
+            style={footerButtonStyle(4)}
+            onPress={() => setSelectedFooterButton(4)}>
+            <Text>Radar</Text>
+            <Text>Chart</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/src/RadarChart/index.tsx
+++ b/src/RadarChart/index.tsx
@@ -426,7 +426,7 @@ export const RadarChart = (props: RadarChartProps) => {
                     (alignmentBaselineLocal as AlignmentBaseline) ?? 'middle'
                   }>
                   {category.split('\n').map((line, idx) => (
-                    <TSpan key={idx} x={x} dy={idx === 0 ? 0 : 14}>
+                    <TSpan key={idx} x={x} dy={idx === 0 ? 0 : fontSizeLocal}>
                       {line}
                     </TSpan>
                   ))}

--- a/src/RadarChart/index.tsx
+++ b/src/RadarChart/index.tsx
@@ -10,6 +10,7 @@ import Svg, {
   Stop,
   TextAnchor,
   AlignmentBaseline,
+  TSpan,
 } from 'react-native-svg';
 
 import {RadarChartProps, useRadarChart} from 'gifted-charts-core';
@@ -424,7 +425,11 @@ export const RadarChart = (props: RadarChartProps) => {
                   alignmentBaseline={
                     (alignmentBaselineLocal as AlignmentBaseline) ?? 'middle'
                   }>
-                  {category}
+                  {category.split('\n').map((line, idx) => (
+                    <TSpan key={idx} x={x} dy={idx === 0 ? 0 : 14}>
+                      {line}
+                    </TSpan>
+                  ))}
                 </SvgText>
               );
             })}


### PR DESCRIPTION
Issue:
The RadarChart component provided by react-native-gifted-charts renders labels using svg text. However, when label text is too long, line breaks are not supported, which reduces readability.

Solution:
We modified the rendering logic so that the label string is split by the \n character and each part is wrapped in a <TSpan> element. This enables proper line breaks for long label texts, resulting in clearer and more readable labels.