### PR TITLE
Fix selection for stack bars

### DIFF
--- a/src/BarChart/RenderStackBars.tsx
+++ b/src/BarChart/RenderStackBars.tsx
@@ -83,7 +83,7 @@ const RenderStackBars = (props: StackedBarChartPropsType) => {
         disabled={disablePress || (stackHighlightEnabled && !highlightEnabled)}
         activeOpacity={activeOpacity}
         onPress={() => {
-          setSelectedIndex(index);
+          setSelectedIndex([index]);
           if (item.onPress) {
             item.onPress();
           } else if (props.onPress) {
@@ -165,7 +165,7 @@ const RenderStackBars = (props: StackedBarChartPropsType) => {
           }
           activeOpacity={activeOpacity}
           onPress={() => {
-            setSelectedIndex(index);
+            setSelectedIndex([index]);
             if (item.onPress) {
               item.onPress();
             } else if (props.onPress) {


### PR DESCRIPTION
# Issue

Selecting a stack bar does not currently work. 
When debugging, I found out the issue is that the `selectedIndex` state is supposed to be of type `number[]` for a StackBars chart, but we call `setSelectedIndex` by passing a `number`.
Then when we want to pass the selectedIndex as a prop we pick `selectedIndex[0]`, which is `undefined`.


The screenshot below is taken when re-rendering the chart after tapping on a stack bar. You can see that `selectedIndex` is `6`, when we should get `[6]`.

<img width="2422" height="1470" alt="image" src="https://github.com/user-attachments/assets/56633c00-d7a1-4266-97a7-79b99b4a119d" />



# Suggested fix

Pass a `number[]` whenever `setSelectedIndex` is called in `src/BarChart/RenderStackBars.tsx`.

Let me know if you want me to create a sample app where you can test both the current version and the fix, I'm happy to do so :) 
