### PR TITLE
Fix secondary line chart misplaced when rendered on stacked bar chart on Web

### DIFF
--- a/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/index.tsx
@@ -42,7 +42,6 @@ const RenderLineInBarChart = (props: LineInBarChartPropsType) => {
   const svgHeight = containerHeightIncludingBelowXAxis + labelsExtraHeight;
 
   const svgHeightProp = isWebApp ? svgHeight : undefined;
-  const svgWidthProp = isWebApp ? totalWidth : undefined;
 
   const dataPointsProps: DataPointProps = {
     data,
@@ -99,7 +98,7 @@ const RenderLineInBarChart = (props: LineInBarChartPropsType) => {
         <Svg
           pointerEvents={isIos ? 'none' : 'box-none'}
           height={svgHeightProp}
-          width={svgWidthProp}>
+          width={isWebApp ? animatedWidth : undefined}>
           <Path
             d={points}
             fill="none"
@@ -143,7 +142,7 @@ const RenderLineInBarChart = (props: LineInBarChartPropsType) => {
         <Svg
           pointerEvents={isIos ? 'none' : 'box-none'}
           height={svgHeightProp}
-          width={svgWidthProp}>
+          width={isWebApp ? totalWidth : undefined}>
           <Path
             d={points}
             fill="none"


### PR DESCRIPTION
Hey @Abhinandan-Kushwaha as updating the package version haven't solved the issue I was facing I decided to give it a try myself :)

<img width="1113" height="357" alt="image" src="https://github.com/user-attachments/assets/74fd69a4-4fed-412e-824c-bfac7648735f" />

Possibly, we could only include the `width`s and `height`s to `<Svg/>` elements when `isWebApp` is set to true, let me know what you think!

Closes #1187 