### PR TITLE
Fix console error on web and misplaced line in stacked bar chart for animated variant

### DIFF
--- a/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/index.tsx
+++ b/src/Components/BarAndLineChartsWrapper/renderLineInBarChart/index.tsx
@@ -83,6 +83,8 @@ const RenderLineInBarChart = (props: LineInBarChartPropsType) => {
   };
 
   const renderAnimatedLine = () => {
+    const bottomOffset = isWebApp ? -10 : 50;
+
     return (
       <Animated.View
         pointerEvents={isIos ? 'none' : 'box-none'} // in iOS box-none doesn't work as expected
@@ -90,7 +92,7 @@ const RenderLineInBarChart = (props: LineInBarChartPropsType) => {
           position: 'absolute',
           height: svgHeight,
           left: 6 - yAxisLabelWidth,
-          bottom: 50 + xAxisLabelsVerticalShift, //stepHeight * -0.5 + xAxisThickness,
+          bottom: bottomOffset + xAxisLabelsVerticalShift, //stepHeight * -0.5 + xAxisThickness,
           width: animatedWidth,
           zIndex: lineBehindBars ? -1 : 100000,
           // backgroundColor: 'wheat',


### PR DESCRIPTION
Hey @Abhinandan-Kushwaha I realised `width` prop is not needed in `Svg` when rendering a line inside stacked bar chart on web.

In fact, it only throws an error that is logged on the console:
<img width="701" height="71" alt="error" src="https://github.com/user-attachments/assets/15a7e85f-19c1-474e-9d80-fe56e1f89ce1" />
The `height` is required though to fix #1191, `width` can be removed and inherited from parent.

Moreover, the `bottom` value for web variant only when line is animated had to be readjusted to avoid the exact same issue with misplacement:

https://github.com/user-attachments/assets/2969e398-8427-483c-bbf1-efc45e3912bf


https://github.com/user-attachments/assets/e64ebb83-7d02-4bb5-9600-dd453accb27f

