### PR TITLE
Fix: Default lineGradient to false for areaChart

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -347,6 +347,7 @@ export const LineChart = (props: LineChartPropsType) => {
     colors,
   } = useLineChart({
     ...props,
+    lineGradient: props.lineGradient ?? (props.areaChart ? false : undefined),
     parentWidth: props.parentWidth ?? screenWidth,
   });
 
@@ -1279,7 +1280,7 @@ export const LineChart = (props: LineChartPropsType) => {
   };
 
   const getColorBackRects = () => {
-    return colors?.map(colorItem => {
+    return colors?.map((colorItem: { from: any; to: any; color: any; }) => {
       const key = JSON.stringify(colorItem);
       const {from, to, color} = colorItem;
       const y = getY(from);


### PR DESCRIPTION
When areaChart is enabled, the line now defaults to solid color instead of gradient. This prevents unexpected gradient lines in area charts unless explicitly set.

Changes:
- Modified useLineChart call to set lineGradient: false when areaChart is true, and lineGradient is not provided


Issue: https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/1080 