### PR TITLE
fix: Check for data point existence before accessing hidePointer in LineChart

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -1786,7 +1786,7 @@ export const LineChart = (props: LineChartPropsType) => {
     factor = Math.max(factor, 0);
     let item, y;
     item = (data0 ?? data)[factor];
-    if (!item.hidePointer) {
+    if (item && !item.hidePointer) {
       let z =
         getX(
           dataSet?.length ? cumulativeSpacingForSet[0] : cumulativeSpacing1,


### PR DESCRIPTION
Fix to the : https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/1216 (Error: Cannot read property 'hidePointer' of undefined" on empty LineChart (dataSet) )

### Steps to reproduce

```ts
const GIFTED_CHART_REPRO_LINE2 = [
  {value: 6},
  {value: 14},
  {value: 10},
  {value: 18},
  {value: 12},
]

<LineChart
    data={[]}
    data2={GIFTED_CHART_REPRO_LINE2}
    maxValue={20}
    pointerConfig={{
        pointerStripColor: 'grey',
        pointerStripWidth: 1,
    }}
/>        
```

1. Run the above code snippet
2. Click on the chart

<img src="https://github.com/user-attachments/assets/b20359ec-54a2-4933-b3d5-49712bff8a3d" alt="hidePointer-crash" width="300" />

-----------------

### RootCause

When `pointerConfig` is set and a user touches the line chart, the code looks up the data point under the finger by index. For `data2` - `data5`, it already checks whether the point exists before using it, but for the data series, it skips that check.

So, if the primary `data` array is empty, it attempts to read `.hidePointer` on undefined, which causes a crash..



### Solution
Check that the data point exists before accessing .hidePointer on the primary series (same as done in data2–data5). Also null-check renderPointer's dataSet lookup.

