### PR TITLE
LineChart: fix focusProximity ignoring presses on negative-range data…

### DIFF
--- a/src/LineChart/index.tsx
+++ b/src/LineChart/index.tsx
@@ -734,9 +734,9 @@ export const LineChart = (props: LineChartPropsType) => {
               {key === lastLineNumber - 1 ? (
                 <Rect
                   x={initialSpacing + (spacing * index - spacing / 2)}
-                  y={8}
+                  y={0}
                   width={spacing}
-                  height={containerHeight - 0}
+                  height={containerHeightIncludingBelowXAxis}
                   fill={'none'}
                   onPressIn={evt => {
                     const locationY = evt.nativeEvent.locationY; // Note that we have another property named pageY which can be useful


### PR DESCRIPTION
The transparent <Rect> that catches press events for focus had height set
to containerHeight, covering only the area above the x-axis. Charts with
negative values render their data points below the x-axis (in the
fourthQuadrantHeight region), which fell entirely outside this Rect, so
handleFocus was never invoked there and focusProximity had no effect.

Use containerHeightIncludingBelowXAxis - 8 (already exposed by
useLineChart as extendedContainerHeight + fourthQuadrantHeight) so the
Rect spans the full chart height. For all-positive charts
fourthQuadrantHeight is 0, so behavior is unchanged.